### PR TITLE
add hoc that scrolls to top of page on client side route change

### DIFF
--- a/example/client/src/components/ScrollToTop.js
+++ b/example/client/src/components/ScrollToTop.js
@@ -1,0 +1,16 @@
+import React, { Component, } from 'react';
+import { withRouter, } from 'react-router-dom';
+
+class ScrollToTop extends Component {
+
+  componentDidUpdate() {
+      window.scrollTo(0,0);
+  };
+
+  render() {
+    return this.props.children;
+  };
+
+};
+
+export default withRouter(ScrollToTop);

--- a/example/client/src/index.js
+++ b/example/client/src/index.js
@@ -7,13 +7,16 @@ import { Provider } from 'react-redux';
 import store from './store';
 import 'semantic-ui-css/semantic.min.css';
 import { initMiddleware } from 'devise-axios';
+import ScrollToTop from './components/ScrollToTop';
 
 initMiddleware()
 
 ReactDOM.render(
   <Provider store={store}>
     <BrowserRouter>
-      <App />
+      <ScrollToTop>
+        <App />
+      </ScrollToTop>
     </BrowserRouter>
   </Provider>,
   document.getElementById('root')


### PR DESCRIPTION
I don't know if this is a common occurrence for you or anyone else but I notice that when I use the --full flag and I change my route (assuming I have scrolled down on my previous page) when I get to the new route the page is rendered at the window height of the previous page. It seems like a new page should start at the top and not the middle. Don't know if this is the most solid way to solve the issue but it is a way I have solved it in my apps. Totally open to any suggestions or renaming of components, etc... Thanks!
--

Or I guess I could just add that scrollTo in App.js. I think I did it that way to reduce clutter in App.js. Just not sure the best direction to take here.